### PR TITLE
Update 2.5.4.md

### DIFF
--- a/guidelines/2.5.4.md
+++ b/guidelines/2.5.4.md
@@ -42,7 +42,7 @@ Fixing this will ensure users:
 * A functionality that can only be activated by moving, shaking or tilting the device. For example: 
   * When inputting text on an iPhone, shaking the device shows a dialog where you can undo the text input. That dialog can be disabled, but there's no other way to cancel the last action.
 * The user is unable to disable motion actuation. For example:
-  * Imagine an app where users can tilt their device to scroll down a page, and there's way to disable that response to tilting.
+  * Imagine an app where users can tilt their device to scroll down a page, but there's no way to disable that response to tilting.
   
 ### Official wording in the Web Content Accessibility Guidelines
 


### PR DESCRIPTION
Clarified an example, making it clear that making it clear that the there being "**no** way to disable that response" made it a failure